### PR TITLE
Update models.jsx

### DIFF
--- a/frontend/gpt4all.io/src/components/models.jsx
+++ b/frontend/gpt4all.io/src/components/models.jsx
@@ -43,7 +43,7 @@ const ModelsTable = () =>
 
     return (
         <div className="flex flex-col justify-center gap-4 mx-auto">
-            <h2 className="text-4xl font-bold text-center mb-2">Model Explorer</h2>
+            <h2 id="model-explorer" className="text-4xl font-bold text-center mb-2">Model Explorer</h2>
             <Select onValueChange={onSelect}>
                 <SelectTrigger className="w-[300px] sm:w-[400px] mx-auto">
                     <SelectValue placeholder={models[0] && models[0].filename}/>


### PR DESCRIPTION
I've added an `id`  attribute to the 'Model Explorer' <h2> title for linking with fragment links, e.g. `#model-explorer`.

Note: I'm really unfamiliar with React, so this might be entirely the wrong way to do it. In that case, just close this, but you get the idea.

The main goal here was to be able to directly link to 'Model Explorer', for the people who have download problems.